### PR TITLE
Fix EOT session handling

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -278,6 +278,7 @@ public class XL200Server {
             logger.debug("Sent ENQ");
         } else if (respondingResults) {
             XL200LISCommunicator.pushResults(patientDataBundle);
+            respondingResults = false;
         } else {
             logger.debug("Received EOT, ending session");
         }


### PR DESCRIPTION
## Summary
- clear the `respondingResults` flag after results are pushed

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc5cbe3b4832f8c302ebaa66a10bb