### PR TITLE
Add session summary logging

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -62,6 +62,11 @@ public class XL200Server {
     OrderRecord orderRecord;
     QueryRecord queryRecord;
 
+    // Session tracking fields for diagnostic logging
+    private long sessionStartMillis;
+    private List<String> sampleIdsInSession;
+    private int resultCount;
+
     private static ServerSocket serverSocket;
     private static int port; // Port needs to be static for restart
 
@@ -120,11 +125,17 @@ public class XL200Server {
     }
 
     private void handleClient(Socket clientSocket) {
-        try (InputStream in = new BufferedInputStream(clientSocket.getInputStream()); OutputStream out = new BufferedOutputStream(clientSocket.getOutputStream())) {
+        try (InputStream in = new BufferedInputStream(clientSocket.getInputStream());
+                OutputStream out = new BufferedOutputStream(clientSocket.getOutputStream())) {
             StringBuilder asciiDebugInfo = new StringBuilder();
             boolean sessionActive = true;
             boolean inChecksum = false;
             int checksumCount = 0;
+
+            // Initialize session tracking metrics
+            sessionStartMillis = System.currentTimeMillis();
+            sampleIdsInSession = new ArrayList<>();
+            resultCount = 0;
 
             while (sessionActive) {
                 int data = in.read();
@@ -194,6 +205,15 @@ public class XL200Server {
             }
         } catch (IOException e) {
             logger.error("Error during client communication", e);
+        } finally {
+            long sessionEndMillis = System.currentTimeMillis();
+            long durationSeconds = (sessionEndMillis - sessionStartMillis) / 1000;
+
+            logger.info("Session completed:");
+            logger.info("  Duration         : {} seconds", durationSeconds);
+            logger.info("  Result Records   : {}", resultCount);
+            logger.info("  Sample IDs       : {}", String.join(", ", sampleIdsInSession));
+            logger.info("  Client           : {}", clientSocket.getInetAddress().getHostAddress());
         }
     }
 
@@ -540,6 +560,13 @@ public class XL200Server {
                             logger.debug("Result Record Parsed: " + resultRecord);
                             logger.debug("Parsed sample ID: " + resultRecord.getSampleId()
                                     + ", Test code: " + resultRecord.getTestCode());
+
+                            // Track metrics for this session
+                            resultCount++;
+                            String sid = resultRecord.getSampleId();
+                            if (sid != null && !sid.isEmpty() && !sampleIdsInSession.contains(sid)) {
+                                sampleIdsInSession.add(sid);
+                            }
                         }
                     } catch (Exception ex) {
                         logger.error("Failed to parse result record: " + record, ex);


### PR DESCRIPTION
## Summary
- track sample IDs and result count for each client connection
- report session duration, count and samples when connection ends

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d9c67c920832f8ef38ab35a9148a3