### PR TITLE
Maintain sample ID across result parsing

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -97,6 +97,8 @@ public class XL200Server {
         DataBundle db = new DataBundle();
         db.setMiddlewareSettings(XL200SettingsLoader.getSettings());
 
+        String currentSampleId = null;
+
         for (String rec : records) {
             if (rec.startsWith("P|")) {
                 PatientRecord pr = XL200Parsers.parsePatientRecord(rec);
@@ -104,8 +106,10 @@ public class XL200Server {
             } else if (rec.startsWith("O|")) {
                 QueryRecord qr = XL200Parsers.parseQueryRecord(rec);
                 db.getQueryRecords().add(qr);
+                currentSampleId = qr.getSampleId();
             } else if (rec.startsWith("R|")) {
                 ResultsRecord rr = XL200Parsers.parseResultsRecord(rec);
+                rr.setSampleId(currentSampleId);
                 db.getResultsRecords().add(rr);
             }
         }


### PR DESCRIPTION
## Summary
- store the current sample ID while processing records
- attach the current sample ID to each results record

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684de0d09c1c832f8d7596dfd9a22f83