### PR TITLE
Add option to ignore LIMS response failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # XL-200 Middleware
+
+## Ignoring LIMS Responses
+
+In environments where the middleware should continue operating even when the
+Laboratory Information Management System (LIMS) is unreachable or returns an
+unexpected status code, set the `ignoreLimsResponse` flag. When enabled, the
+middleware will log warnings for failed HTTP responses but will treat them as
+successful.
+
+Enable the flag with either a JVM system property:
+
+```bash
+java -DignoreLimsResponse=true -jar xl200.jar
+```
+
+or by setting the environment variable before starting the application:
+
+```bash
+export IGNORE_LIMS_RESPONSE=true
+java -jar xl200.jar
+```

--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200LISCommunicator.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200LISCommunicator.java
@@ -23,6 +23,23 @@ public class XL200LISCommunicator {
     private static final Logger logger = LogManager.getLogger(XL200LISCommunicator.class);
     private static final Gson gson = new Gson();
 
+    /**
+     * When set to {@code true} the middleware will ignore non successful
+     * responses from the LIMS server. The value can be provided either via the
+     * system property {@code ignoreLimsResponse} or the environment variable
+     * {@code IGNORE_LIMS_RESPONSE}.
+     */
+    private static final boolean IGNORE_LIMS_RESPONSE = Boolean.parseBoolean(
+        System.getProperty(
+            "ignoreLimsResponse",
+            System.getenv().getOrDefault("IGNORE_LIMS_RESPONSE", "false")
+        )
+    );
+
+    public static boolean isIgnoreLimsResponse() {
+        return IGNORE_LIMS_RESPONSE;
+    }
+
     public static DataBundle pullTestOrdersForSampleRequests(QueryRecord queryRecord) {
         logger.info("pullTestOrdersForSampleRequests");
         try {
@@ -66,7 +83,7 @@ public class XL200LISCommunicator {
         return null;
     }
 
-    public static void pushResults(DataBundle patientDataBundle) {
+    public static boolean pushResults(DataBundle patientDataBundle) {
         try {
             String pushResultsEndpoint = XL200SettingsLoader.getSettings().getLimsSettings().getLimsServerBaseUrl() + "/test_results";
             URL url = new URL(pushResultsEndpoint);
@@ -85,7 +102,7 @@ public class XL200LISCommunicator {
             }
 
             int responseCode = conn.getResponseCode();
-            if (responseCode == HttpURLConnection.HTTP_OK) {
+            if (responseCode == HttpURLConnection.HTTP_OK || IGNORE_LIMS_RESPONSE) {
                 BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream(), "utf-8"));
                 StringBuilder response = new StringBuilder();
                 String inputLine;
@@ -112,11 +129,21 @@ public class XL200LISCommunicator {
                     logger.info("Sample ID: {}, Test: {}, Status: {}",
                         record.getSampleId(), record.getTestCode(), record.getStatus());
                 }
+                if (responseCode != HttpURLConnection.HTTP_OK) {
+                    logger.warn("POST request failed with {} but IGNORE_LIMS_RESPONSE is active", responseCode);
+                }
+                return true;
             } else {
                 logger.error("POST request failed. Response code: {}", responseCode);
+                return false;
             }
         } catch (Exception e) {
+            if (IGNORE_LIMS_RESPONSE) {
+                logger.warn("Exception in pushResults but IGNORE_LIMS_RESPONSE is active", e);
+                return true;
+            }
             logger.error("Exception in pushResults", e);
+            return false;
         }
     }
 } 

--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -115,7 +115,10 @@ public class XL200Server {
         }
 
         if (!db.getResultsRecords().isEmpty()) {
-            XL200LISCommunicator.pushResults(db);
+            boolean success = XL200LISCommunicator.pushResults(db);
+            if (!success && !XL200LISCommunicator.isIgnoreLimsResponse()) {
+                logger.warn("Failed to push results to LIMS");
+            }
         }
         return db;
     }


### PR DESCRIPTION
## Summary
- add a configurable flag to ignore LIMS server failures
- make `pushResults` return a boolean and honour the flag
- log failures in `XL200Server` if result push failed
- document the new flag

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504483682c832f88147b6979591be3