### PR TITLE
Improve EOT handling in XL200Server

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -68,8 +68,21 @@ public class XL200Server {
                     out.write(ACK);
                     out.flush();
                 } else if (b == EOT) {
-                    logger.debug("Received EOT. Session complete.");
-                    break;
+                    logger.debug("Received EOT.");
+                    if (frame.length() > 0) {
+                        String message = frame.toString();
+                        logger.debug("Received ASTM Frame: {}", message);
+                        List<String> records = splitRecords(message);
+                        DataBundle db = processRecords(records);
+                        resultCount = db.getResultsRecords().size();
+                        if (db.getPatientRecord() != null) {
+                            sampleIds.add(db.getPatientRecord().getPatientId());
+                        }
+                        out.write(ACK);
+                        out.flush();
+                    }
+                    frame.setLength(0);
+                    // continue waiting for next transmission
                 } else {
                     frame.append((char) b);
                 }


### PR DESCRIPTION
## Summary
- keep XL200Server session alive after receiving `EOT`
- process any buffered frame on `EOT` and clear the buffer

## Testing
- `javac -d target/classes @sources.txt` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504f5e0170832fb07d113f9a810b09