### PR TITLE
Add configurable settings path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,23 @@ or by setting the environment variable before starting the application:
 export IGNORE_LIMS_RESPONSE=true
 java -jar xl200.jar
 ```
+
+## Custom Configuration Location
+
+By default the middleware loads its settings from
+`C:\CCMW\SysmaxXS500i\settings\XL200\config.json`. To use a different file,
+provide the path via the `xl200.config.path` system property or the
+`XL200_CONFIG_PATH` environment variable.
+
+Example using the system property:
+
+```bash
+java -Dxl200.config.path=/path/to/config.json -jar xl200.jar
+```
+
+Or set the environment variable:
+
+```bash
+export XL200_CONFIG_PATH=/path/to/config.json
+java -jar xl200.jar
+```

--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200SettingsLoader.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200SettingsLoader.java
@@ -13,12 +13,16 @@ public class XL200SettingsLoader {
 
     private static final Logger logger = LogManager.getLogger(XL200SettingsLoader.class);
     private static MiddlewareSettings middlewareSettings;
+    private static final String DEFAULT_CONFIG_PATH =
+        "C\\CCMW\\SysmaxXS500i\\settings\\XL200\\config.json";
 
     public static void loadSettings() {
         Gson gson = new Gson();
+        String filePath = System.getProperty(
+            "xl200.config.path",
+            System.getenv().getOrDefault("XL200_CONFIG_PATH", DEFAULT_CONFIG_PATH)
+        );
         try {
-            // Read and print the contents of the config.json file
-            String filePath = "C:\\CCMW\\SysmaxXS500i\\settings\\XL200\\config.json";
             String jsonContent = new String(Files.readAllBytes(Paths.get(filePath)));
             logger.debug("Contents of config.json:");
             logger.debug(jsonContent);
@@ -26,7 +30,7 @@ public class XL200SettingsLoader {
             // Now parse the JSON content
             try (FileReader reader = new FileReader(filePath)) {
                 middlewareSettings = gson.fromJson(reader, MiddlewareSettings.class);
-                logger.info("Settings loaded from config.json");
+                logger.info("Settings loaded from " + filePath);
 
                 // Debugging output
                 logger.debug("MiddlewareSettings loaded:");
@@ -45,7 +49,7 @@ public class XL200SettingsLoader {
                 }
             }
         } catch (IOException e) {
-            logger.error("Failed to load settings from config.json", e);
+            logger.error("Failed to load settings from " + filePath, e);
             logger.error("Failed to load settings: " + e.getMessage());
         }
     }


### PR DESCRIPTION
## Summary
- allow overriding config path through `xl200.config.path` or `XL200_CONFIG_PATH`
- document the new option

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504ffcc870832f9fa7d55b65c35528