### PR TITLE
Handle Q record queries

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -116,10 +116,11 @@ public class XL200Server {
             if (rec.startsWith("P|")) {
                 PatientRecord pr = XL200Parsers.parsePatientRecord(rec);
                 db.setPatientRecord(pr);
-            } else if (rec.startsWith("O|")) {
+            } else if (rec.startsWith("Q|")) {
                 QueryRecord qr = XL200Parsers.parseQueryRecord(rec);
                 db.getQueryRecords().add(qr);
                 currentSampleId = qr.getSampleId();
+                logger.debug("Query for sample ID: {}", currentSampleId);
                 // Forward query record to the LIMS to fetch any pending test orders
                 XL200LISCommunicator.pullTestOrdersForSampleRequests(qr);
             } else if (rec.startsWith("R|")) {


### PR DESCRIPTION
## Summary
- correctly detect query records using prefix `Q|`
- log the sample ID from query records
- ensure the middleware forwards queries to the LIMS

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68519a25a924832f9d203fd6cfeb15ce