### PR TITLE
Fix sample ID parsing and add test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
             <artifactId>lims-middleware-libraries</artifactId>
             <version>1.1.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>
@@ -70,6 +76,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M9</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Parsers.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Parsers.java
@@ -20,7 +20,8 @@ public class XL200Parsers {
 
     public static QueryRecord parseQueryRecord(String record) {
         String[] fields = record.split("\\|");
-        String sampleId = fields.length > 2 ? fields[2].split("\\^")[0] : "";
+        String[] parts = fields.length > 2 ? fields[2].split("\\^") : new String[0];
+        String sampleId = parts.length > 1 ? parts[1] : parts[0];
         return new QueryRecord(0, sampleId, "", "");
     }
 

--- a/src/test/java/org/carecode/mw/lims/mw/xl200/XL200ParsersTest.java
+++ b/src/test/java/org/carecode/mw/lims/mw/xl200/XL200ParsersTest.java
@@ -1,0 +1,14 @@
+package org.carecode.mw.lims.mw.xl200;
+
+import org.carecode.lims.libraries.QueryRecord;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class XL200ParsersTest {
+    @Test
+    void parseQueryRecord_extractsSampleIdAfterCaret() {
+        QueryRecord record = XL200Parsers.parseQueryRecord("Q|1|^1857128");
+        assertEquals("1857128", record.getSampleId());
+    }
+}


### PR DESCRIPTION
## Summary
- parse sample IDs correctly in `parseQueryRecord`
- add JUnit5 test dependency and Surefire plugin
- test sample ID extraction for query records

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519b3f86ac832fa80bd06ad643efb7