### PR TITLE
Improve logging for LIMS query requests

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -121,6 +121,9 @@ public class XL200Server {
                 db.getQueryRecords().add(qr);
                 currentSampleId = qr.getSampleId();
                 logger.debug("Query for sample ID: {}", currentSampleId);
+                String endpoint = XL200SettingsLoader.getSettings().getLimsSettings()
+                    .getLimsServerBaseUrl() + "/test_orders_for_sample_requests";
+                logger.debug("Pulling test orders for sample {} from {}", currentSampleId, endpoint);
                 // Forward query record to the LIMS to fetch any pending test orders
                 XL200LISCommunicator.pullTestOrdersForSampleRequests(qr);
             } else if (rec.startsWith("R|")) {


### PR DESCRIPTION
## Summary
- add debug logging of sample ID, endpoint, response code and body when pulling test orders
- log endpoint in `processRecords` before calling the communicator

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519c02284c832f9fa32fcf51c4b8af