### PR TITLE
Handle ETX trailing checksum

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -67,6 +67,15 @@ public class XL200Server {
                     }
                     out.write(ACK);
                     out.flush();
+
+                    // Discard checksum (2 bytes) and trailing CR/LF after ETX
+                    for (int i = 0; i < 4; i++) {
+                        if (in.read() == -1) {
+                            break;
+                        }
+                    }
+                    // Reset for next transmission
+                    frame.setLength(0);
                 } else if (b == EOT) {
                     logger.debug("Received EOT.");
                     if (frame.length() > 0) {


### PR DESCRIPTION
## Summary
- discard checksum bytes and CR/LF after ETX
- reset frame when ETX completes to prepare for next transmission

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a3e61580832f88413286025a4915