### PR TITLE
Handle query record messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,10 @@ Or set the environment variable:
 export XL200_CONFIG_PATH=/path/to/config.json
 java -jar xl200.jar
 ```
+
+## Query Record Handling
+
+When the analyzer sends a query record the middleware now forwards the sample ID
+to the LIMS using the `/test_orders_for_sample_requests` endpoint. Any test
+codes present in the query are extracted and forwarded so multiple requested
+tests are handled correctly.

--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Parsers.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Parsers.java
@@ -21,7 +21,30 @@ public class XL200Parsers {
     public static QueryRecord parseQueryRecord(String record) {
         String[] fields = record.split("\\|");
         String sampleId = fields.length > 2 ? fields[2].split("\\^")[0] : "";
-        return new QueryRecord(0, sampleId, "", "");
+
+        // ASTM query records may optionally specify one or more test codes in
+        // the universal test ID field (typically field index 4). These are
+        // separated by backslashes when multiple tests are requested. Extract
+        // them so they can be forwarded to the LIMS if present.
+        String testCodes = "";
+        if (fields.length > 4 && !fields[4].isEmpty()) {
+            String[] tests = fields[4].split("\\\\");
+            StringBuilder parsed = new StringBuilder();
+            for (int i = 0; i < tests.length; i++) {
+                String[] parts = tests[i].split("\\^");
+                String code = parts.length > 3 ? parts[3]
+                        : parts[parts.length - 1];
+                if (!code.isEmpty()) {
+                    if (parsed.length() > 0) {
+                        parsed.append(',');
+                    }
+                    parsed.append(code);
+                }
+            }
+            testCodes = parsed.toString();
+        }
+
+        return new QueryRecord(0, sampleId, sampleId, testCodes);
     }
 
     public static ResultsRecord parseResultsRecord(String record) {

--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -120,6 +120,8 @@ public class XL200Server {
                 QueryRecord qr = XL200Parsers.parseQueryRecord(rec);
                 db.getQueryRecords().add(qr);
                 currentSampleId = qr.getSampleId();
+                // Forward query record to the LIMS to fetch any pending test orders
+                XL200LISCommunicator.pullTestOrdersForSampleRequests(qr);
             } else if (rec.startsWith("R|")) {
                 ResultsRecord rr = XL200Parsers.parseResultsRecord(rec);
                 rr.setSampleId(currentSampleId);


### PR DESCRIPTION
## Summary
- forward query sample IDs to LIMS when received
- document query record handling
- extract multiple test codes from query records

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68519764e024832f899ad3c5bcf9e842