### PR TITLE
Fix query record detection

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -116,7 +116,7 @@ public class XL200Server {
             if (rec.startsWith("P|")) {
                 PatientRecord pr = XL200Parsers.parsePatientRecord(rec);
                 db.setPatientRecord(pr);
-            } else if (rec.startsWith("O|")) {
+            } else if (rec.startsWith("Q|")) {
                 QueryRecord qr = XL200Parsers.parseQueryRecord(rec);
                 db.getQueryRecords().add(qr);
                 currentSampleId = qr.getSampleId();


### PR DESCRIPTION
## Summary
- handle query records with `Q|` prefix in `XL200Server`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851af0baf28832f95aba75b0b977c9f