### PR TITLE
Add XL200 query record parsing tests

### DIFF
--- a/src/test/java/org/carecode/mw/lims/mw/xl200/XL200ParsersTest.java
+++ b/src/test/java/org/carecode/mw/lims/mw/xl200/XL200ParsersTest.java
@@ -11,4 +11,18 @@ class XL200ParsersTest {
         QueryRecord record = XL200Parsers.parseQueryRecord("Q|1|^1857128");
         assertEquals("1857128", record.getSampleId());
     }
+
+    @Test
+    void parseQueryRecord_extractsSampleIdWithMultipleCarets() {
+        QueryRecord record =
+            XL200Parsers.parseQueryRecord("Q|1|^^^1857128^|||");
+        assertEquals("1857128", record.getSampleId());
+    }
+
+    @Test
+    void parseQueryRecord_parsesMultipleRequestedTests() {
+        QueryRecord record =
+            XL200Parsers.parseQueryRecord("Q|1|^1857128||^^^GLU\\^^^UREA");
+        assertEquals("GLU,UREA", record.getTestCodes());
+    }
 }


### PR DESCRIPTION
## Summary
- add tests for parsing query records with multiple carets
- verify that multiple requested tests are parsed to comma separated list

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b2b12540832fb5a6a41cd5941ab5