### PR TITLE
Handle ASTM order records

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -122,6 +122,9 @@ public class XL200Server {
                 currentSampleId = qr.getSampleId();
                 // Forward query record to the LIMS to fetch any pending test orders
                 XL200LISCommunicator.pullTestOrdersForSampleRequests(qr);
+            } else if (rec.startsWith("O|")) {
+                OrderRecord or = XL200Parsers.parseOrderRecord(rec);
+                db.getOrderRecords().add(or);
             } else if (rec.startsWith("R|")) {
                 ResultsRecord rr = XL200Parsers.parseResultsRecord(rec);
                 rr.setSampleId(currentSampleId);


### PR DESCRIPTION
## Summary
- parse ASTM order records in `XL200Parsers`
- add handling for order records when processing ASTM frames

## Testing
- `gradle test --no-daemon` *(fails: Directory does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_6851b77a2bf8832fbdfe57b5aa804d0d