### PR TITLE
Fix checksum frame logic

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200LISCommunicator.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200LISCommunicator.java
@@ -153,7 +153,6 @@ public class XL200LISCommunicator {
         sb.append(STX);
         sb.append((char) ('0' + (frameNumber % 8)));
         sb.append(line);
-        sb.append(CR);
         sb.append(ETX);
         String checksum = calculateChecksum(sb.toString());
         sb.append(checksum);


### PR DESCRIPTION
## Summary
- correct ASTM frame construction

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a0b38dd0832fa7141bdff9338835