### PR TITLE
Adjust ASTM frame cycling

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200LISCommunicator.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200LISCommunicator.java
@@ -135,7 +135,7 @@ public class XL200LISCommunicator {
             out.flush();
             logger.debug("Sent ASTM line: {}", rec);
 
-            frameNum = frameNum % 7 + 1; // cycle 1..7
+            frameNum = (frameNum + 1) % 8;
 
             try {
                 Thread.sleep(200); // slight delay to avoid analyzer overflow


### PR DESCRIPTION
## Summary
- update frame number logic when sending ASTM response blocks

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a13a8bb0832fbbab4adff059296b