### PR TITLE
Handle NAK retransmission

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200LISCommunicator.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200LISCommunicator.java
@@ -110,7 +110,7 @@ public class XL200LISCommunicator {
         return false;
     }
 
-    public static void sendAstmResponseBlock(DataBundle bundle, OutputStream out) throws IOException {
+    public static void sendAstmResponseBlock(DataBundle bundle, OutputStream out, java.util.function.Consumer<String> sentCallback) throws IOException {
         logger.info("Sending ASTM response for sample {}", bundle.getPatientRecord().getPatientId());
 
         List<String> records = new ArrayList<>();
@@ -133,6 +133,9 @@ public class XL200LISCommunicator {
             String framed = buildAstmFrame(frameNum, rec);
             out.write(framed.getBytes());
             out.flush();
+            if (sentCallback != null) {
+                sentCallback.accept(framed);
+            }
             logger.debug("Sent ASTM line: {}", rec);
 
             frameNum = (frameNum + 1) % 8;


### PR DESCRIPTION
## Summary
- store the last frame transmitted in `handleClient`
- resend the frame when a NAK is received
- expose a callback in `sendAstmResponseBlock` to capture transmitted frames

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a4c4f6f4832f880a57bc4af92ecf