### PR TITLE
Fix EOT handling

### DIFF
--- a/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
+++ b/src/main/java/org/carecode/mw/lims/mw/xl200/XL200Server.java
@@ -94,7 +94,6 @@ public class XL200Server {
                 } else if (b == EOT) {
                     logger.debug("Received EOT.");
                     frame.setLength(0);
-                    break;
                 } else {
                     frame.append((char) b);
                 }


### PR DESCRIPTION
## Summary
- keep reading after EOT by removing the break

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a6197054832fbfdcb44201655c52